### PR TITLE
BST-83006 Endpoints /stats/drafts-per-version, /stats/drafts-expiration-queue

### DIFF
--- a/app/uk/gov/hmrc/tctr/backend/controllers/StatsController.scala
+++ b/app/uk/gov/hmrc/tctr/backend/controllers/StatsController.scala
@@ -21,10 +21,8 @@ import play.api.libs.json.Format.GenericFormat
 import play.api.libs.json._
 import play.api.mvc._
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
-import uk.gov.hmrc.tctr.backend.models.stats.{Draft, DraftsExpirationQueue, DraftsPerVersion}
 import uk.gov.hmrc.tctr.backend.repository.MongoSubmissionDraftRepo
 
-import java.time.LocalDate
 import javax.inject.Inject
 import scala.concurrent.ExecutionContext
 
@@ -38,15 +36,13 @@ class StatsController @Inject() (
     extends BackendController(cc)
     with Logging {
 
-  def draftsPerVersion: Action[AnyContent] = Action.async { implicit request =>
-    val draftsPerVersion = List(
-      DraftsPerVersion("0.79.0", 9, LocalDate.now.plusDays(2)),
-      DraftsPerVersion("0.78.0", 2, LocalDate.now.plusDays(1))
-    )
-    Ok(Json.toJson(draftsPerVersion))
+  def draftsPerVersion: Action[AnyContent] = Action.async {
+    submissionDraftRepo.getDraftsPerVersion.map { draftsPerVersion =>
+      Ok(Json.toJson(draftsPerVersion))
+    }
   }
 
-  def draftsExpirationQueue: Action[AnyContent] = Action.async { implicit request =>
+  def draftsExpirationQueue: Action[AnyContent] = Action.async {
     submissionDraftRepo.getDraftsExpirationQueue(100).map { draftsExpirationQueue =>
       Ok(Json.toJson(draftsExpirationQueue))
     }

--- a/app/uk/gov/hmrc/tctr/backend/controllers/StatsController.scala
+++ b/app/uk/gov/hmrc/tctr/backend/controllers/StatsController.scala
@@ -47,15 +47,9 @@ class StatsController @Inject() (
   }
 
   def draftsExpirationQueue: Action[AnyContent] = Action.async { implicit request =>
-    val draftsExpirationQueue = DraftsExpirationQueue(
-      List(
-        Draft("Reference_01", "6010", "0.79.0", LocalDate.now.plusDays(2)),
-        Draft("Reference_02", "6015", "0.79.0", LocalDate.now.plusDays(2)),
-        Draft("Reference_03", "6015", "0.78.0", LocalDate.now.plusDays(1))
-      ),
-      1077
-    )
-    Ok(Json.toJson(draftsExpirationQueue))
+    submissionDraftRepo.getDraftsExpirationQueue(100).map { draftsExpirationQueue =>
+      Ok(Json.toJson(draftsExpirationQueue))
+    }
   }
 
 }

--- a/app/uk/gov/hmrc/tctr/backend/controllers/StatsController.scala
+++ b/app/uk/gov/hmrc/tctr/backend/controllers/StatsController.scala
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.tctr.backend.controllers
+
+import play.api.Logging
+import play.api.libs.json.Format.GenericFormat
+import play.api.libs.json._
+import play.api.mvc._
+import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
+import uk.gov.hmrc.tctr.backend.models.stats.{Draft, DraftsExpirationQueue, DraftsPerVersion}
+import uk.gov.hmrc.tctr.backend.repository.MongoSubmissionDraftRepo
+
+import java.time.LocalDate
+import javax.inject.Inject
+import scala.concurrent.ExecutionContext
+
+/**
+  * Read-only stats controller.
+  */
+class StatsController @Inject() (
+  submissionDraftRepo: MongoSubmissionDraftRepo,
+  cc: ControllerComponents
+)(implicit ec: ExecutionContext)
+    extends BackendController(cc)
+    with Logging {
+
+  def draftsPerVersion: Action[AnyContent] = Action.async { implicit request =>
+    val draftsPerVersion = List(
+      DraftsPerVersion("0.79.0", 9, LocalDate.now.plusDays(2)),
+      DraftsPerVersion("0.78.0", 2, LocalDate.now.plusDays(1))
+    )
+    Ok(Json.toJson(draftsPerVersion))
+  }
+
+  def draftsExpirationQueue: Action[AnyContent] = Action.async { implicit request =>
+    val draftsExpirationQueue = DraftsExpirationQueue(
+      List(
+        Draft("Reference_01", "6010", "0.79.0", LocalDate.now.plusDays(2)),
+        Draft("Reference_02", "6015", "0.79.0", LocalDate.now.plusDays(2)),
+        Draft("Reference_03", "6015", "0.78.0", LocalDate.now.plusDays(1))
+      ),
+      1077
+    )
+    Ok(Json.toJson(draftsExpirationQueue))
+  }
+
+}

--- a/app/uk/gov/hmrc/tctr/backend/models/aboutyouandtheproperty/AboutYouAndTheProperty.scala
+++ b/app/uk/gov/hmrc/tctr/backend/models/aboutyouandtheproperty/AboutYouAndTheProperty.scala
@@ -34,7 +34,7 @@ case class AboutYouAndTheProperty(
   tiedForGoods: Option[AnswersYesNo] = None,
   tiedForGoodsDetails: Option[TiedForGoodsInformationDetails] = None,
   checkYourAnswersAboutTheProperty: Option[CheckYourAnswersAboutYourProperty] = None,
-  propertyDetailsString: Option[PropertyDetailsString] = None, //added for 6030 - February 2024
+  propertyDetailsString: Option[PropertyDetailsString] = None //added for 6030 - February 2024
 )
 
 object AboutYouAndTheProperty {

--- a/app/uk/gov/hmrc/tctr/backend/models/aboutyouandtheproperty/PropertyDetailsString.scala
+++ b/app/uk/gov/hmrc/tctr/backend/models/aboutyouandtheproperty/PropertyDetailsString.scala
@@ -19,8 +19,8 @@ package uk.gov.hmrc.tctr.backend.models.aboutyouandtheproperty
 import play.api.libs.json.Json
 
 case class PropertyDetailsString(
-                                  propertyDetailsString: String
-                                )
+  propertyDetailsString: String
+)
 
 object PropertyDetailsString {
   implicit val format = Json.format[PropertyDetailsString]

--- a/app/uk/gov/hmrc/tctr/backend/models/stats/Draft.scala
+++ b/app/uk/gov/hmrc/tctr/backend/models/stats/Draft.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.tctr.backend.models.stats
+
+import play.api.libs.json.{Json, OFormat}
+
+import java.time.LocalDate
+
+/**
+  * @author Yuriy Tumakha
+  */
+case class Draft(reference: String, forType: String, version: String, expireOn: LocalDate)
+
+object Draft {
+  implicit val format: OFormat[Draft] = Json.format
+}

--- a/app/uk/gov/hmrc/tctr/backend/models/stats/Draft.scala
+++ b/app/uk/gov/hmrc/tctr/backend/models/stats/Draft.scala
@@ -17,8 +17,11 @@
 package uk.gov.hmrc.tctr.backend.models.stats
 
 import play.api.libs.json.{Json, OFormat}
+import uk.gov.hmrc.tctr.backend.models.SubmissionDraftWrapper
+import uk.gov.hmrc.tctr.backend.repository.MongoSubmissionDraftRepo.saveForDays
 
-import java.time.LocalDate
+import java.time.{LocalDate, ZoneOffset}
+import scala.util.Try
 
 /**
   * @author Yuriy Tumakha
@@ -27,4 +30,13 @@ case class Draft(reference: String, forType: String, version: String, expireOn: 
 
 object Draft {
   implicit val format: OFormat[Draft] = Json.format
+
+  def apply(sd: SubmissionDraftWrapper): Draft =
+    Draft(
+      sd._id,
+      Try((sd.submissionDraft \ "forType").as[String]).map(_.filter(_.isDigit)).getOrElse(""),
+      sd.appVersion.getOrElse(""),
+      sd.createdAt.atZone(ZoneOffset.UTC).toLocalDate.plusDays(saveForDays)
+    )
+
 }

--- a/app/uk/gov/hmrc/tctr/backend/models/stats/DraftsExpirationQueue.scala
+++ b/app/uk/gov/hmrc/tctr/backend/models/stats/DraftsExpirationQueue.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.tctr.backend.models.stats
+
+import play.api.libs.json.{Json, OFormat}
+
+
+/**
+ * @author Yuriy Tumakha
+ */
+case class DraftsExpirationQueue(drafts: List[Draft], total: Long)
+
+object DraftsExpirationQueue {
+  implicit val format: OFormat[DraftsExpirationQueue] = Json.format
+}

--- a/app/uk/gov/hmrc/tctr/backend/models/stats/DraftsExpirationQueue.scala
+++ b/app/uk/gov/hmrc/tctr/backend/models/stats/DraftsExpirationQueue.scala
@@ -18,10 +18,9 @@ package uk.gov.hmrc.tctr.backend.models.stats
 
 import play.api.libs.json.{Json, OFormat}
 
-
 /**
- * @author Yuriy Tumakha
- */
+  * @author Yuriy Tumakha
+  */
 case class DraftsExpirationQueue(drafts: Seq[Draft], total: Long)
 
 object DraftsExpirationQueue {

--- a/app/uk/gov/hmrc/tctr/backend/models/stats/DraftsExpirationQueue.scala
+++ b/app/uk/gov/hmrc/tctr/backend/models/stats/DraftsExpirationQueue.scala
@@ -22,7 +22,7 @@ import play.api.libs.json.{Json, OFormat}
 /**
  * @author Yuriy Tumakha
  */
-case class DraftsExpirationQueue(drafts: List[Draft], total: Long)
+case class DraftsExpirationQueue(drafts: Seq[Draft], total: Long)
 
 object DraftsExpirationQueue {
   implicit val format: OFormat[DraftsExpirationQueue] = Json.format

--- a/app/uk/gov/hmrc/tctr/backend/models/stats/DraftsPerVersion.scala
+++ b/app/uk/gov/hmrc/tctr/backend/models/stats/DraftsPerVersion.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.tctr.backend.models.stats
+
+import play.api.libs.json.{Json, OFormat}
+
+import java.time.LocalDate
+
+/**
+  * @author Yuriy Tumakha
+  */
+case class DraftsPerVersion(version: String, drafts: Long, expireOn: LocalDate)
+
+object DraftsPerVersion {
+  implicit val format: OFormat[DraftsPerVersion] = Json.format
+}

--- a/app/uk/gov/hmrc/tctr/backend/util/DateUtil.scala
+++ b/app/uk/gov/hmrc/tctr/backend/util/DateUtil.scala
@@ -38,7 +38,7 @@ object DateUtil {
   val timeFormatter: DateTimeFormatter      = DateTimeFormatter.ofPattern("HH:mm", Locale.UK)
 
   implicit class instantOps(instant: Instant) {
-   def toLocalDate: LocalDate = instant.atZone(ZoneOffset.UTC).toLocalDate
+    def toLocalDate: LocalDate = instant.atZone(ZoneOffset.UTC).toLocalDate
   }
 
   implicit class dateOps(date: Date) {

--- a/app/uk/gov/hmrc/tctr/backend/util/DateUtil.scala
+++ b/app/uk/gov/hmrc/tctr/backend/util/DateUtil.scala
@@ -21,7 +21,7 @@ import uk.gov.hmrc.play.language.LanguageUtils
 import uk.gov.hmrc.tctr.backend.util.DateUtil.dateOps
 
 import java.time.format.DateTimeFormatter
-import java.time.{LocalDate, ZoneId, ZonedDateTime}
+import java.time.{Instant, LocalDate, ZoneId, ZoneOffset, ZonedDateTime}
 import java.util.{Date, Locale}
 import javax.inject.{Inject, Singleton}
 
@@ -36,6 +36,10 @@ object DateUtil {
 
   val shortDateFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern("dd/MM/yyyy", Locale.UK)
   val timeFormatter: DateTimeFormatter      = DateTimeFormatter.ofPattern("HH:mm", Locale.UK)
+
+  implicit class instantOps(instant: Instant) {
+   def toLocalDate: LocalDate = instant.atZone(ZoneOffset.UTC).toLocalDate
+  }
 
   implicit class dateOps(date: Date) {
     def asZonedDateTime: ZonedDateTime = date.toInstant.atZone(ukTimezone)

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -12,5 +12,8 @@ PUT           /submissions/connected/:referenceNumber           uk.gov.hmrc.tctr
 
 PUT           /submissions/requestRefNum                        uk.gov.hmrc.tctr.backend.controllers.RequestRefNumSubmissionController.submit
 
+GET           /stats/drafts-per-version                         uk.gov.hmrc.tctr.backend.controllers.StatsController.draftsPerVersion
+GET           /stats/drafts-expiration-queue                    uk.gov.hmrc.tctr.backend.controllers.StatsController.draftsExpirationQueue
+
 +nocsrf
 POST          /upscan/callback                                  uk.gov.hmrc.tctr.backend.controllers.UpscanCallbackController.callback

--- a/it/test/uk/gov/hmrc/tctr/backend/StatsControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/tctr/backend/StatsControllerISpec.scala
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.tctr.backend
+
+import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
+import play.api.http.Status.OK
+import play.api.libs.json.Json
+import uk.gov.hmrc.tctr.backend.models.stats.{DraftsExpirationQueue, DraftsPerVersion}
+import uk.gov.hmrc.tctr.backend.repository.MongoSubmissionDraftRepo
+
+class StatsControllerISpec extends IntegrationSpecBase with BeforeAndAfterAll with BeforeAndAfterEach {
+
+  private val statsIdPrefix = "StatsTestDraft"
+  private val repo          = app.injector.instanceOf[MongoSubmissionDraftRepo]
+  override def beforeAll(): Unit = {
+    repo.save(statsIdPrefix + 6015, Json.obj("a" -> "b", "forType" -> "FOR6015"))
+    repo.save(statsIdPrefix + 6011, Json.obj("c" -> "d", "forType" -> "FOR6011"))
+  }
+
+  "StatsController - SubmissionDraft stats endpoints" should {
+    "return consistent stats" in {
+      val response1 =
+        wsClient
+          .url(s"$appBaseUrl/stats/drafts-expiration-queue")
+          .get()
+          .futureValue
+
+      response1.status shouldBe OK
+      val expirationQueue = Json.parse(response1.body).as[DraftsExpirationQueue]
+
+      val response2 =
+        wsClient
+          .url(s"$appBaseUrl/stats/drafts-per-version")
+          .get()
+          .futureValue
+
+      response2.status shouldBe OK
+      val draftsPerVersion = Json.parse(response2.body).as[Seq[DraftsPerVersion]]
+      println(response1.body)
+
+      draftsPerVersion.map(_.drafts).sum shouldBe expirationQueue.total
+      draftsPerVersion.length shouldBe expirationQueue.drafts.map(_.version).distinct.length
+      draftsPerVersion.head.expireOn shouldBe expirationQueue.drafts.head.expireOn
+    }
+  }
+
+}

--- a/it/test/uk/gov/hmrc/tctr/backend/StatsControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/tctr/backend/StatsControllerISpec.scala
@@ -52,8 +52,8 @@ class StatsControllerISpec extends IntegrationSpecBase with BeforeAndAfterAll wi
       val draftsPerVersion = Json.parse(response2.body).as[Seq[DraftsPerVersion]]
 
       draftsPerVersion.map(_.drafts).sum shouldBe expirationQueue.total
-      draftsPerVersion.length shouldBe expirationQueue.drafts.map(_.version).distinct.length
-      draftsPerVersion.head.expireOn shouldBe expirationQueue.drafts.head.expireOn
+      draftsPerVersion.length            shouldBe expirationQueue.drafts.map(_.version).distinct.length
+      draftsPerVersion.head.expireOn     shouldBe expirationQueue.drafts.head.expireOn
     }
   }
 

--- a/it/test/uk/gov/hmrc/tctr/backend/StatsControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/tctr/backend/StatsControllerISpec.scala
@@ -50,7 +50,6 @@ class StatsControllerISpec extends IntegrationSpecBase with BeforeAndAfterAll wi
 
       response2.status shouldBe OK
       val draftsPerVersion = Json.parse(response2.body).as[Seq[DraftsPerVersion]]
-      println(response1.body)
 
       draftsPerVersion.map(_.drafts).sum shouldBe expirationQueue.total
       draftsPerVersion.length shouldBe expirationQueue.drafts.map(_.version).distinct.length


### PR DESCRIPTION
Added TCTR backend endpoints to show data on TCTR admin frontend:
- http://localhost:9527/tenure-cost-and-trade-records/stats/drafts-expiration-queue
- http://localhost:9527/tenure-cost-and-trade-records/stats/drafts-per-version