### PR TITLE
BST-139281 Apply the right MongoDB codec for Java time values

### DIFF
--- a/app/uk/gov/hmrc/tctr/backend/models/RefNum.scala
+++ b/app/uk/gov/hmrc/tctr/backend/models/RefNum.scala
@@ -17,7 +17,8 @@
 package uk.gov.hmrc.tctr.backend.models
 
 import org.mongodb.scala.bson.ObjectId
-import play.api.libs.json.{Json, OFormat}
+import play.api.libs.json.{Format, Json, OFormat}
+import uk.gov.hmrc.mongo.play.json.formats.MongoJavatimeFormats
 
 import java.time.Instant
 
@@ -25,6 +26,6 @@ case class RefNum(referenceNumber: String, createdAt: Instant, _id: Option[Objec
 
 object RefNum {
   import uk.gov.hmrc.mongo.play.json.formats.MongoFormats.Implicits._
-
+  implicit val formatInstant: Format[Instant] = MongoJavatimeFormats.instantFormat
   implicit val format: OFormat[RefNum] = Json.format
 }

--- a/app/uk/gov/hmrc/tctr/backend/models/SensitiveConnectedSubmission.scala
+++ b/app/uk/gov/hmrc/tctr/backend/models/SensitiveConnectedSubmission.scala
@@ -16,8 +16,9 @@
 
 package uk.gov.hmrc.tctr.backend.models
 
-import play.api.libs.json.{Json, OFormat}
+import play.api.libs.json.{Format, Json, OFormat}
 import uk.gov.hmrc.crypto.Sensitive
+import uk.gov.hmrc.mongo.play.json.formats.MongoJavatimeFormats
 import uk.gov.hmrc.tctr.backend.crypto.MongoCrypto
 import uk.gov.hmrc.tctr.backend.models.aboutYourLeaseOrTenure.*
 import uk.gov.hmrc.tctr.backend.models.aboutfranchisesorlettings.AboutFranchisesOrLettings
@@ -84,7 +85,7 @@ case class SensitiveConnectedSubmission(
   )
 
 object SensitiveConnectedSubmission:
-
+  implicit val formatInstant: Format[Instant]                                           = MongoJavatimeFormats.instantFormat
   implicit def format(using crypto: MongoCrypto): OFormat[SensitiveConnectedSubmission] = Json.format
 
   def apply(connectedSubmission: ConnectedSubmission): SensitiveConnectedSubmission = SensitiveConnectedSubmission(

--- a/app/uk/gov/hmrc/tctr/backend/repository/SubmittedMongoRepo.scala
+++ b/app/uk/gov/hmrc/tctr/backend/repository/SubmittedMongoRepo.scala
@@ -22,7 +22,8 @@ import org.mongodb.scala.model.Filters.equal
 import org.mongodb.scala.model._
 import org.mongodb.scala.result.InsertOneResult
 import uk.gov.hmrc.mongo.MongoComponent
-import uk.gov.hmrc.mongo.play.json.PlayMongoRepository
+import uk.gov.hmrc.mongo.play.json.formats.MongoJavatimeFormats
+import uk.gov.hmrc.mongo.play.json.{Codecs, PlayMongoRepository}
 import uk.gov.hmrc.tctr.backend.config.AppConfig
 import uk.gov.hmrc.tctr.backend.models.RefNum
 
@@ -50,7 +51,8 @@ class SubmittedMongoRepo @Inject() (mongo: MongoComponent, appConfig: AppConfig)
         )
       ),
       extraCodecs = Seq(
-        new ObjectIdCodec
+        new ObjectIdCodec,
+        Codecs.playFormatCodec(MongoJavatimeFormats.instantFormat)
       )
     ) {
 

--- a/test/uk/gov/hmrc/tctr/backend/testUtils/FakeObjects.scala
+++ b/test/uk/gov/hmrc/tctr/backend/testUtils/FakeObjects.scala
@@ -97,13 +97,14 @@ trait FakeObjects {
   val prefilledDateInput: LocalDate               = LocalDate.of(2022, 6, 1)
   val today: LocalDate                            = LocalDate.now
   val prefilledMonthYearInput: MonthsYearDuration = MonthsYearDuration(6, 2000)
+  val prefilledCreatedAt: Instant                 = Instant.parse("2007-12-03T10:15:30.00Z")
 
   val hundred: BigDecimal = BigDecimal(100)
 
   val prefilledTradingNameOperatingFromProperty: String = "TRADING NAME"
 
   val baseFilledConnectedSubmission: ConnectedSubmission =
-    ConnectedSubmission(referenceNumber, forType6010, prefilledAddress, token, Instant.now())
+    ConnectedSubmission(referenceNumber, forType6010, prefilledAddress, token, prefilledCreatedAt)
 
   val prefilledStillConnectedDetailsYesToAll: StillConnectedDetails = StillConnectedDetails(
     Some(AddressConnectionTypeYes),
@@ -692,7 +693,7 @@ trait FakeObjects {
         "BN12 4AX"
       ), //  Address,
       token = "dummyToken",
-      createdAt = Instant.now(),
+      createdAt = prefilledCreatedAt,
       stillConnectedDetails = Some(prefilledStillConnectedDetailsYesToAll),
       aboutYouAndTheProperty = Some(prefilledAboutYouAndTheProperty),
       aboutYouAndThePropertyPartTwo = Some(prefilledAboutYouAndThePropertyPartTwo),
@@ -716,7 +717,7 @@ trait FakeObjects {
     Some("test@test.com"),
     Some("12312312312"),
     Some("additional info"),
-    Instant.now.truncatedTo(MILLIS),
+    prefilledCreatedAt,
     false
   )
 
@@ -727,7 +728,7 @@ trait FakeObjects {
     "fullName",
     ContactDetails("john@example.com", "01234567890"),
     Option("some other information"),
-    Instant.now(),
+    prefilledCreatedAt,
     "en"
   )
 
@@ -740,7 +741,7 @@ trait FakeObjects {
       fullName = "Full Name",
       contactDetails = prefilledContactDetails,
       additionalInformation = Some("Additional information"),
-      createdAt = Instant.now(),
+      createdAt = prefilledCreatedAt,
       lang = Some("en")
     )
 }


### PR DESCRIPTION
This is the same as https://github.com/hmrc/tenure-cost-and-trade-records/pull/235 (which has been closed by mistake)